### PR TITLE
Pass non-base64 secret as raw string to jsrsasign.

### DIFF
--- a/src/JsonWebTokenDynamicValue.js
+++ b/src/JsonWebTokenDynamicValue.js
@@ -36,7 +36,7 @@ class JsonWebTokenDynamicValue {
 
     const secret = this.signatureSecretIsBase64
       ? {b64: jsrsasign.b64utob64(this.signatureSecret)}
-      : this.signatureSecret;
+      : {rstr: this.signatureSecret};
 
     return jsrsasign.jws.JWS.sign(null, header, payload, secret);
   }


### PR DESCRIPTION
I had trouble getting this working at first, realized that jsrsasign has some automatic encoding detection based on the secret value. See https://github.com/kjur/jsrsasign/wiki/Tutorial-for-JWT-generation#jwtio-site-interoperability for more details.

I chose raw string but UTF8 is also an option.
